### PR TITLE
Parameter dimensionality typo and Residual Standard Error Clarification

### DIFF
--- a/linear_models.qmd
+++ b/linear_models.qmd
@@ -970,7 +970,7 @@ If we look back at our results, we can see this expressed as the part of the out
 
 ```{r}
 #| label: my-first-model-mse-r
-# summary(model_lr_rating) # 'Residual standard error' is approx RMSE
+# summary(model_lr_rating) # 'Residual standard error' = sqrt(SSR/(n-p-1)) 
 summary(model_lr_rating)$sigma   # We can extract it directly
 ```
 
@@ -979,7 +979,7 @@ summary(model_lr_rating)$sigma   # We can extract it directly
 
 ```{python}
 #| label: my-first-model-mse-py
-np.sqrt(model_lr_rating.scale)   # RMSE
+np.sqrt(model_lr_rating.scale)   # OLSResults.scale provides the 'Residual standard error'
 ```
 
 :::
@@ -1086,7 +1086,7 @@ $$
 \end{bmatrix}
 $$ {#eq-lm-mat-x}
 
-And finally, here is the $p \times 1$, vector of coefficients:
+And finally, here is the $(p+1) \times 1$, vector of coefficients:
 
 $$
 \bf{\beta} = \begin{bmatrix}


### PR DESCRIPTION
**Residual SE Clarification:** `statsmodels.regression.linear_model.OLSResults.scale()` provides the Residual Standard Error (divides by $(n-p-1)$, rather than the pure RMSE (divides by $n$). Change is made to make this more clear. 

**Beta Parameters Dimensionality: ** The correct dimensionality of the $\boldsymbol\beta$ vector would be $(p+1) \times 1$ rather than $p \times 1$, due to the inclusion of the intercept, and the index of the last parameter being $p$ rather than $p-1$. $(p+1) \times 1$ appears to be more consistent with how the parameterization is presented throughout the section.


Potential additional clarification/transparency could be given in Section 3.4.2: "Model Metrics" by showing consistency between manual calculation of $R^2$ and `OLSResults.rsquared` implementation:

```python
import numpy as np

# R^2 = 1 - MSE / var(y)
r_squared = 1 - np.mean((y - predictions)**2)/np.var(y) 
r_squared == model_lr_rating.rsquared  
```
